### PR TITLE
Fix error for new users.

### DIFF
--- a/src/ext/lib/Settings.js
+++ b/src/ext/lib/Settings.js
@@ -194,7 +194,7 @@ class Settings {
         'info', 
         'settings', 
         '[Settings::init] settings don\'t exist. Using defaults.\n#keys:', 
-        settings != null ? Object.keys(settings).length : 0, 
+        settings ? Object.keys(settings).length : 0, 
         '\nsettings:', 
         settings
       );

--- a/src/ext/lib/Settings.js
+++ b/src/ext/lib/Settings.js
@@ -190,7 +190,14 @@ class Settings {
 
     // if there's no settings saved, return default settings.
     if(! settings || (Object.keys(settings).length === 0 && settings.constructor === Object)) {
-      this.logger.log('info', 'settings', '[Settings::init] settings don\'t exist. Using defaults.\n#keys:', Object.keys(settings).length, '\nsettings:', settings);
+      this.logger.log(
+        'info', 
+        'settings', 
+        '[Settings::init] settings don\'t exist. Using defaults.\n#keys:', 
+        settings != null ? Object.keys(settings).length : 0, 
+        '\nsettings:', 
+        settings
+      );
       this.active = this.getDefaultSettings();
       this.active.version = this.version;
       await this.save();


### PR DESCRIPTION
Hey, sorry for intruding. I've been using this extension on one of my browser and I love it. I recently wanted to install it in Chrome but it wasn't working. I noticed this error in the console.

![Annotation 2019-09-24 213841](https://user-images.githubusercontent.com/20268283/65571148-749a7700-df18-11e9-86d4-d5556cd96af1.png)

`Object.keys` throws when what's passed in is undefined/null, which causes the extension to never work for new users in this case.

I've tried to test by loading the unpacked extension but I kept seeing some unrelated errors.

Happy to tweak/test however necessary. Or just feel free to ignore this and fix yourself 👍 Would just love to use it. Thanks!
